### PR TITLE
Add HTTPS link to it

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,6 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
-    site: 'betonjeanette.github.io',
+    site: 'https://betonjeanette.github.io',
     base: 'DivisibilityClock'
 });


### PR DESCRIPTION
# What was the problem?
The link did not have an HTTPS prefix, causing a crash

# What does this do to Fix it?
I added the HTTPS prefix