### PR TITLE
25-slow-to-render-new-graphs

### DIFF
--- a/src/components/diagram.tsx
+++ b/src/components/diagram.tsx
@@ -36,15 +36,16 @@ function Diagram({divisor}: IDiagramProps){
 function GetGraph(divisor: Accessor<number>): Graph{
     const graph = new Graph({allowSelfLoops: true});
     const nodes = Array.from(Array(divisor()).keys())
-    
     const edges = nodes.map(val => (val * 10) % divisor())
+    
     nodes.forEach(node => {
         graph.addNode(node, {label: node.toString(), x:node, y: node, size: 10 })
     });
 
-    for (let index = 0; index < divisor(); index++){
-        graph.addDirectedEdge(index, (index * 10) % divisor(), {type: "arrow", size: 3})
-    };
+    edges.forEach((dest, source) =>{
+        graph.addDirectedEdge(source, dest, {type: "arrow", size: 3})
+    });
+    
     circular.assign(graph, {scale: 100});
 
     return graph;

--- a/src/components/diagram.tsx
+++ b/src/components/diagram.tsx
@@ -16,8 +16,11 @@ function Diagram({divisor}: IDiagramProps){
     let graphDisplay: Sigma | undefined;
     createEffect(() => {
         const graph = GetGraph(divisor)
-        graphDisplay?.kill();
-        graphDisplay = new Sigma(graph, diagramElement, {});
+        if (graphDisplay == undefined) {
+            graphDisplay = new Sigma(graph, diagramElement);
+        } else {
+            graphDisplay.setGraph(graph)
+        }
         graphDisplay.viewportToFramedGraph;
     })
     const diagramContainer = <div id="DiagramContainer" ref={diagramElement}></div>
@@ -32,10 +35,12 @@ function Diagram({divisor}: IDiagramProps){
  */
 function GetGraph(divisor: Accessor<number>): Graph{
     const graph = new Graph({allowSelfLoops: true});
+    const nodes = Array.from(Array(divisor()).keys())
     
-    for (let index = 0; index < divisor(); index++){
-        graph.addNode(index, {label: index.toString(), x: index, y: index, size: 10});
-    }
+    const edges = nodes.map(val => (val * 10) % divisor())
+    nodes.forEach(node => {
+        graph.addNode(node, {label: node.toString(), x:node, y: node, size: 10 })
+    });
 
     for (let index = 0; index < divisor(); index++){
         graph.addDirectedEdge(index, (index * 10) % divisor(), {type: "arrow", size: 3})


### PR DESCRIPTION
# What was the Problem?
Creating a new sigma instance each time was causing a massive bottleneck in performance, taking over half a second to render each new graph.

# What does this do to Fix the Problem?
Rather than killing and restarting sigma each time the graph changes, we create it once and replace the graph each time afterward.